### PR TITLE
✨ migrate xai-google-gemini to use new `google-genai` SDK

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-google-generativeai==0.8.3
+google-genai==1.19.0
 grpcio-status==1.62.3
 pillow==10.4.0


### PR DESCRIPTION

# Description

This PR updates the xai-google-gemini component library to use the new `google-genai` SDK instead of the deprecated `google-generativeai`.

- Rewrote all components using the `genai.Client` interface
- Ensured `ctx["genai_client"]` is used to pass the client across components
- Default model used: `models/gemini-1.5-flash`

## Pull Request Type

- [x] Xircuits Component Library Code
- [ ] Workflow Example
- [ ] Documentation
- [ ] Others (Please Specify)

## Type of Change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


## Tested on?

- [ ] Windows  
- [x] Linux Fedora 
- [ ] Centos 
- [ ] Mac  
- [ ] Others  (State here -> xxx )  

